### PR TITLE
Clarify `web3` version in dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evm-lite-lib",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "A Node.js module for interacting with EVM-Lite.",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
@@ -19,7 +19,7 @@
     "solc": "^0.4.25",
     "toml": "^2.3.3",
     "tomlify-j0.4": "^3.0.0",
-    "web3": "github:ethereum/web3.js",
+    "web3": "^0.20.7",
     "web3-eth-accounts": "^1.0.0-beta.26"
   },
   "devDependencies": {


### PR DESCRIPTION
ethereum/web3.js has been updated to v.1.0 yesterday, 
it has a completely different file structure,
it causes `SolidityFunction.ts` can't import the needed file,
so we need to specify the version to 0.20.7 to avoid errors.